### PR TITLE
rails4対応　fix routes(match->http method)

### DIFF
--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -14,7 +14,7 @@ class ParticipationsController < ApplicationController
 
   def destroy
     participation = current_schedule.license_participations
-                                    .find_by_user_id(current_user.id)
+                                    .find_by(user_id: current_user.id)
 
     if participation && participation.destroy
       render :json => participation

--- a/app/controllers/schedulers_controller.rb
+++ b/app/controllers/schedulers_controller.rb
@@ -23,7 +23,8 @@ class SchedulersController < ApplicationController
   end
 
   def create
-    @schedule = Schedule.new(params[:schedule])
+    permitted_params= params.require(:schedule).permit(:id, :project_id, :title,:license, :color)
+    @schedule = Schedule.new(permitted_params)
     if @schedule.save
       render :template => "schedulers/create",
              :handlers => [:erb],

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,7 @@ class Event < ActiveRecord::Base
   private
   def update_count
     self.start_date.upto(self.end_date) do |date|
-      license_count = LicenseCount.find_or_initialize_by_schedule_id_and_date(self.schedule_id, date)
+      license_count = LicenseCount.find_or_initialize_by(schedule_id: self.schedule_id, date: date)
       license_count.count += 1
       license_count.save
     end
@@ -20,9 +20,9 @@ class Event < ActiveRecord::Base
 
   def check_license
     self.start_date.upto(self.end_date) do |date|
-      license_count = self.schedule.license_counts.find_by_date(date)
+      license_count = self.schedule.license_counts.find_by(date: date)
       next unless license_count
-      if license_count.count >= self.schedule.license
+      if license_count.count.to_i >= self.schedule.license
         self.errors.add(:date, "#{date}のライセンス数の上限にひっかかっています")
         return false
       end
@@ -31,7 +31,7 @@ class Event < ActiveRecord::Base
 
   def destroy_license_count
     self.start_date.upto(self.end_date || self.start_date) do |date|
-      license_count = self.schedule.license_counts.find_by_date(date)
+      license_count = self.schedule.license_counts.find_by(date: date)
       license_count.count -= 1
       license_count.save
     end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -25,7 +25,7 @@ class Schedule < ActiveRecord::Base
       color: color,
       events: self.events.where("start_date >= ?", date)
                          .where("start_date < ?", date + 1.month),
-      visiable: self.license_participations.find_by_user_id(User.current.id) ? false : true }
+      visiable: self.license_participations.find_by(user_id: User.current.id) ? false : true }
   end
 
   private

--- a/app/views/settings/_period.html.erb
+++ b/app/views/settings/_period.html.erb
@@ -16,7 +16,6 @@
     var _put_period = $("#scheduler_setting_period").val();
     var put_data = "period=" + _put_period;
     var url = "/scheduler_settings/1"
-
     $.ajax({
       type: "PUT",
       headers: {
@@ -26,7 +25,7 @@
       data: put_data,
       dataType: "json",
       success: function(d) {
-        $("input#scheduler_setting_period").val(d["scheduler_setting"]["period"]);
+        $("input#scheduler_setting_period").val(d["period"]);
       },
       error: function(xhr, status, error) {
         console.log(status);

--- a/assets/javascripts/pochi_calendar.js
+++ b/assets/javascripts/pochi_calendar.js
@@ -243,7 +243,7 @@ eventService.factory("Event", function($resource, LicenseManager) {
     this.create = function(success, error) {
       var self = this;
       var callback = function(e, _) {
-        var event = self.to_calendar(e.event);
+        var event = self.to_calendar(e);
         self.set_id(event);
         LicenseManager.find(event).events.push(event);
         success(event);
@@ -255,8 +255,8 @@ eventService.factory("Event", function($resource, LicenseManager) {
       var self = this;
       var current = angular.copy(this.current);
       var callback = function(e,_) {
-        LicenseManager.replace(self.before, self.to_calendar(e.event));
-        success(self.current, self.to_calendar(e.event));
+        LicenseManager.replace(self.before, self.to_calendar(e));
+        success(self.current, self.to_calendar(e));
       };
       current.$update(callback ,error);
     };
@@ -264,8 +264,8 @@ eventService.factory("Event", function($resource, LicenseManager) {
     this.destroy = function(success, error) {
       var self = this;
       var callback = function(e,_) {
-        LicenseManager.delete(self.current.event);
-        success(self.current.event);
+        LicenseManager.delete(self.current);
+        success(self.current);
       };
       this.current.$delete(callback, error);
     };

--- a/assets/javascripts/pochi_calendar.js
+++ b/assets/javascripts/pochi_calendar.js
@@ -321,7 +321,7 @@ calendarApp.directive('eventFormModal', function(Event) {
       var _split_url = location.href.split("/");
       var project_id = _split_url[_split_url.length - 3];
 
-      scope.last_update_event = $("#last_event").data("articles").event;
+      scope.last_update_event = $("#last_event").data("articles");
       scope.eventForm = false;
 
       scope.closeEventForm = function() {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 
 Rails.application.routes.draw do
   resources :projects do
-    match '/schedulers/home' => 'schedulers#home'
+    get '/schedulers/home' => 'schedulers#home'
     resources :schedulers do
       resources :events, :only => [:create, :update, :destroy]
       resource :participations, :only => [:destroy]
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     end
   end
 
-  match '/schedulers/settings', :to => 'schedulers#settings', :via => :post
+  post '/schedulers/settings', :to => 'schedulers#settings'
   resources :scheduler_custom_list_contents
   resources :scheduler_settings
 end


### PR DESCRIPTION
下記環境でbundle exec rake redmine:plugins:migrateを実施したところエラーが出たのでrails4に対応するよう修正しました。

```
Environment:
  Redmine version                3.3.2.stable
  Ruby version                   2.1.9-p490 (2016-03-30) [x86_64-linux-gnu]
  Rails version                  4.2.7.1
  Environment                    production
  Database adapter               Mysql2
SCM:
  Subversion                     1.8.8
  Darcs                          2.8.4
  Mercurial                      2.8.2
  Cvs                            1.12.13
  Bazaar                         2.7.0
  Git                            2.11.0
  Filesystem                     
Redmine plugins:
  full_text_search               0.3.0
  redmine_backlogs               v1.0.6
  redmine_drafts                 0.2.0
  redmine_github_hook            2.2.0
  redmine_issue_templates        0.1.5
```

```
An error occurred while loading the routes definition of redmine-schedular plugin (/home/redmine/redmine/plugins/redmine-schedular/config/routes.rb): You should not use the `match` method in your router without specifying an HTTP method.
If you want to expose your action to both GET and POST, add `via: [:get, :post]` option.
If you want to expose your action to GET, use `get` in the router:
  Instead of: match "controller#action"
  Do: get "controller#action".
```

確認お願いします。